### PR TITLE
feat: Delete Element API Endpoint for film, live and kontrast shows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const database = require("./database.js");
 const routing = require('./service/routing.js');
 const apiRouting = require('./service/api/apiRouting.js');
 const schedule = require('node-schedule');
+const cloudinary = require('cloudinary');
 
 require('dotenv').config();
 
@@ -38,6 +39,12 @@ app.use(session({
         maxAge: 10800000,  // 3 hours in milliseconds
     },
 }));
+
+cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET
+});
 
 device.enableDeviceHelpers(app);
 

--- a/models/filmModel.js
+++ b/models/filmModel.js
@@ -1,6 +1,12 @@
 const mongoose = require('mongoose');
 const filmSchema = require('./filmSchema')
 
+filmSchema.pre("create", (next) => {
+    this.set({showType: "film"});
+
+    next();
+});
+
 const FilmModel = mongoose.model("Film", filmSchema, "Filmer");
 
 module.exports = FilmModel;

--- a/models/filmSchema.js
+++ b/models/filmSchema.js
@@ -43,6 +43,9 @@ const FilmSchema = new mongoose.Schema({
     premiere:  {
         type: Boolean,
         default: false,
+    },
+    showType: {
+        type: String
     }
 });
 

--- a/models/kontrastModel.js
+++ b/models/kontrastModel.js
@@ -1,6 +1,12 @@
 const mongoose = require('mongoose');
 const filmSchema = require('./filmSchema')
 
+filmSchema.pre("create", (next) => {
+    this.set({showType: "kontrast"});
+
+    next();
+});
+
 const FilmModel = mongoose.model("Kontrast", filmSchema, "BioKontrast");
 
 module.exports = FilmModel;

--- a/models/liveModel.js
+++ b/models/liveModel.js
@@ -1,6 +1,12 @@
 const mongoose = require('mongoose');
 const filmSchema = require('./filmSchema')
 
+filmSchema.pre("create", (next) => {
+    this.set({showType: "live"});
+
+    next();
+});
+
 const FilmModel = mongoose.model("Live", filmSchema, "LiveBio");
 
 module.exports = FilmModel;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcrypt": "^5.1.1",
         "body-parser": "^1.20.2",
+        "cloudinary": "^2.0.1",
         "cookie-parser": "^1.4.6",
         "dotenv": "^16.3.1",
         "ejs": "^3.1.9",
@@ -407,6 +408,18 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cloudinary": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.0.1.tgz",
+      "integrity": "sha512-+j5GswtCwjAmLhjs/K26id4Zvh53zL/YWzgyenxgbdXdXmdFM8d5H1FV1sJCkpS77AqylJKBzyztySdILM+F+A==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
       }
     },
     "node_modules/color-convert": {
@@ -1170,10 +1183,17 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1250,6 +1270,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -1297,6 +1322,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -1891,6 +1921,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -2119,15 +2158,15 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -2144,6 +2183,11 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
+    "cloudinary": "^2.0.1",
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "ejs": "^3.1.9",

--- a/service/films-cache.js
+++ b/service/films-cache.js
@@ -93,13 +93,19 @@ async function updateAllIfNeeded() {
     updateKontrastIfNeeded();
 }
 
-async function updateAll() {
+function updateAll() {
     fetchFilm();
     fetchLive();
     fetchKontrast();
 }
 
-updateAll();
+async function updateAllAsync() {
+    fetchFilm();
+    fetchLive();
+    fetchKontrast();
+}
+
+updateAllAsync();
 
 function getAllCache() {
     updateAllIfNeeded();
@@ -138,6 +144,6 @@ module.exports = {
         else
             return updateAll();
 
-    }, updateAll, updateAllIfNeeded, cache,
+    }, updateAll, updateAllAsync, updateAllIfNeeded, cache,
     
 }


### PR DESCRIPTION
Functionality to delete shows from Database.
Uses the same API endpoint as /sendData.
Requires proper "type" setting in body data set to "DeleteElement" to delete an element.
It also requires an "Element Type" to determine what DB collection to delete from, as well as the ID of the element.

NOTE: There is currently a bug in the cloudinary implementation. It does not delete the poster image from cloudinary. Needs fixing in the future, but low priority as the file sizes are relatively small, and quanity will be small.